### PR TITLE
Root utils: functions to predict .root files by estimators

### DIFF
--- a/hep_ml/reweight.py
+++ b/hep_ml/reweight.py
@@ -17,7 +17,7 @@ Algorithms are implemented as estimators, fitting and reweighting stages are spl
 Fitted reweighter can be applied many times to different data, pickled and so on.
 
 
-Folding over reweighter is also availabel. This provides an easy way to run k-Folding cross-validation.
+Folding over reweighter is also available. This provides an easy way to run k-Folding cross-validation.
 Also it is a nice way to combine weights predictions of trained reweighters.
 
 Examples
@@ -49,6 +49,8 @@ If the same data used in the training process are predicted by folding reweighte
 weights predictions will be unbiased: each reweighter predicts only those part of data which is not used during its training
 
 >>> MC_weights = reweighter.predict_weights(MC_data)
+
+You can use **hep_ml.rootutils** to add weights prediction to the root file in a correct way also for folding scheme.
 """
 from __future__ import division, print_function, absolute_import
 

--- a/hep_ml/rootutils.py
+++ b/hep_ml/rootutils.py
@@ -1,3 +1,8 @@
+"""
+**hep_ml.rootutils** contains some helpful functions to predict data from root files
+and add predictions into them. This functions needs ROOT, rootpy, root_numpy installation.
+"""
+
 from __future__ import print_function, division, absolute_import
 
 import numpy
@@ -53,6 +58,7 @@ def compute_indices_of_intersection(ids_sorted, searched_ids):
 
     :param ids_sorted: sorted full ids vector
     :param searched_ids: searched ids (for them positions in the ids_sorted ara considered)
+
     :return: positions
     """
     positions = numpy.searchsorted(ids_sorted, searched_ids)
@@ -82,9 +88,8 @@ def predict_rootfile_by_estimator(filename, treename, filelength, estimator,
     :param str id_column_name: id column name
     :param str id_column_dtype: dtype of id column
     :param bool id_column_exist: exist or not id column. If not then it will be added.
-    :param estimator_column_name:
-    :param estimator_column_dtype:
-    :return:
+    :param str estimator_column_name: column name for estimator predictions
+    :param str estimator_column_dtype: dtype of predictions
     """
     import root_numpy
 

--- a/hep_ml/rootutils.py
+++ b/hep_ml/rootutils.py
@@ -1,0 +1,131 @@
+from __future__ import print_function, division, absolute_import
+
+import numpy
+import pandas
+from sklearn.base import ClassifierMixin, RegressorMixin
+from .reweight import ReweighterMixin
+
+
+def add_column_to_rootfile(column, filename, treename, dtype, column_name):
+    """
+    Add column to the existence root file.
+    **This function works only if ROOT, rootpy, root_numpy are installed.**
+
+    :param array column: column values
+    :param str filename: root file name
+    :param str treename: tree name
+    :param str dtype: type
+    :param str column_name: creating branch name for adding column
+    """
+    from rootpy.io import root_open
+    import root_numpy
+    with root_open(filename, mode='a') as rootfile:
+        new_column = numpy.array(column, dtype=[(column_name, dtype)])
+        root_numpy.array2tree(new_column, tree=rootfile[treename])
+        rootfile.write()
+
+
+def predict_by_estimator(data, estimator):
+    """
+    Predict samples by estimator: classifier, regressor or reweighter
+
+    :param data: data which are necessary to predict
+    :type data: pandas.DataFrame or array-like
+    :param estimator: trained estimator by which data will be marked
+    :type estimator: ClassifierMixin or RegressorMixin or ReweighterMixin
+
+    :return: predictions
+    """
+    prediction = None
+    if isinstance(estimator, ClassifierMixin):
+        prediction = estimator.predict_proba(data)[:, 1]
+    elif isinstance(estimator, RegressorMixin):
+        prediction = estimator.predict(data)
+    elif isinstance(estimator, ReweighterMixin):
+        prediction = estimator.predict_weights(data)
+    assert prediction is not None, 'estimator cannot predict samples'
+    return prediction
+
+
+def compute_indices_of_intersection(ids_sorted, searched_ids):
+    """
+    Compute positions of the searched ids in the full ids vector
+
+    :param ids_sorted: sorted full ids vector
+    :param searched_ids: searched ids (for them positions in the ids_sorted ara considered)
+    :return: positions
+    """
+    positions = numpy.searchsorted(ids_sorted, searched_ids)
+    match = searched_ids == ids_sorted[positions]
+    return positions[match]
+
+
+def predict_rootfile_by_estimator(filename, treename, filelength, estimator,
+                                  branches, training_selection=None,
+                                  chunk=10000, id_column_name='ID_column', id_column_dtype='i8', id_column_exist=False,
+                                  estimator_column_name='BDT', estimator_column_dtype='f8'):
+    """
+    Predict the whole root file by estimator (classifier, regressor or reweighter) and add predictions into file.
+    Identification value and prediction for each sample will be added.
+    **This function works only if ROOT, rootpy, root_numpy are installed.**
+
+    :param str ilename: root file name
+    :param str treename: tree name
+    :param int filelength: the length of tree
+    :param estimator: trained estimator by which data will be marked
+    :type estimator: ClassifierMixin or RegressorMixin or ReweighterMixin
+    :param list branches: name of columns used by estimator in the same order as for estimator training
+    :param training_selection: selection for training samples,
+     if None then training selection is not used. (This is needed for folding estimators)
+    :type training_selection: str or None
+    :param int chunk: chunk of samples for reading from file
+    :param str id_column_name: id column name
+    :param str id_column_dtype: dtype of id column
+    :param bool id_column_exist: exist or not id column. If not then it will be added.
+    :param estimator_column_name:
+    :param estimator_column_dtype:
+    :return:
+    """
+    import root_numpy
+
+    if not id_column_exist:
+        ids = numpy.arange(filelength)
+        add_column_to_rootfile(ids, filename, treename, id_column_dtype, column_name=id_column_name)
+
+    ids = root_numpy.root2array(filename, treename=treename, branches=[id_column_name])[id_column_name]
+    ids_sorted = numpy.sort(ids)
+    indices_of_ids = numpy.argsort(ids)
+
+    whole_predictions = numpy.zeros(filelength)
+
+    remaining_length = filelength
+
+    test_selection = ""
+    if training_selection is not None:
+        # predict training samples, this is necessary for folding scheme of training which predictions depend on samples
+        training_data = pandas.DataFrame(root_numpy.root2array(filename, treename=treename,
+                                                               branches=list(branches) + [id_column_name],
+                                                               selection=training_selection))
+        training_idices = compute_indices_of_intersection(ids_sorted, training_data[id_column_name].values)
+
+        whole_predictions[indices_of_ids[training_idices]] = predict_by_estimator(training_data, estimator)
+        remaining_length = filelength - len(training_data)
+        test_selection = "!({})".format(training_selection)
+
+    read_samples = 0
+    for _ in range((remaining_length - 1) // chunk + 1):
+        read_sample_last_index = read_samples + chunk
+        if read_sample_last_index > remaining_length:
+            read_sample_last_index = remaining_length
+        if read_samples >= read_sample_last_index:
+            break
+        data = pandas.DataFrame(root_numpy.root2array(filename, treename=treename,
+                                                      branches=list(branches) + [id_column_name],
+                                                      selection= test_selection,
+                                                      start=read_samples, stop=read_sample_last_index))
+
+        indices = compute_indices_of_intersection(ids_sorted, data[id_column_name].values)
+        whole_predictions[indices_of_ids[indices]] = predict_by_estimator(data[branches], estimator)
+        read_samples += chunk
+    add_column_to_rootfile(whole_predictions, filename, treename,
+                           estimator_column_dtype, column_name=estimator_column_name)

--- a/hep_ml/rootutils.py
+++ b/hep_ml/rootutils.py
@@ -86,12 +86,12 @@ def predict_by_estimator(data, estimator):
     :return: predictions
     """
     prediction = None
-    if isinstance(estimator, ClassifierMixin):
+    if isinstance(estimator, ReweighterMixin):
+        prediction = estimator.predict_weights(data)
+    elif isinstance(estimator, ClassifierMixin):
         prediction = estimator.predict_proba(data)[:, 1]
     elif isinstance(estimator, RegressorMixin):
         prediction = estimator.predict(data)
-    elif isinstance(estimator, ReweighterMixin):
-        prediction = estimator.predict_weights(data)
     assert prediction is not None, 'estimator cannot predict samples'
     return prediction
 

--- a/hep_ml/rootutils.py
+++ b/hep_ml/rootutils.py
@@ -60,7 +60,7 @@ def add_column_to_rootfile(column, filename, treename, dtype, column_name):
     Add column to the existence root file.
     **This function works only if ROOT, rootpy, root_numpy are installed.**
 
-    :param array column: column values
+    :param ndarray column: column values
     :param str filename: root file name
     :param str treename: tree name
     :param str dtype: type

--- a/tests/_test_rootutils.py
+++ b/tests/_test_rootutils.py
@@ -1,0 +1,59 @@
+from __future__ import division, print_function
+
+import tempfile
+
+import numpy
+import pandas
+from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor
+from hep_ml.rootutils import predict_rootfile_by_estimator, predict_by_estimator
+from hep_ml.reweight import GBReweighter, ReweighterMixin
+
+
+def check_estimator(estimator, n_dimensions=2, n_samples=200000):
+    mean_original = numpy.random.normal(size=n_dimensions)
+    cov_original = numpy.diag([1.] * n_dimensions)
+
+    mean_target = numpy.random.mtrand.multivariate_normal(mean=mean_original, cov=cov_original)
+    cov_target = cov_original * 0.4 + numpy.ones([n_dimensions, n_dimensions]) * 0.2
+
+    original = numpy.random.mtrand.multivariate_normal(mean=mean_original, cov=cov_original, size=n_samples + 1)
+    original_weight = numpy.ones(n_samples + 1)
+
+    target = numpy.random.mtrand.multivariate_normal(mean=mean_target, cov=cov_target, size=n_samples)
+    target_weight = numpy.ones(n_samples)
+
+    if isinstance(estimator, ReweighterMixin):
+        estimator.fit(original, target, original_weight=original_weight, target_weight=target_weight)
+    else:
+        data = numpy.vstack([original, target])
+        labels = [0] * (n_samples + 1) + [1] * n_samples
+        estimator.fit(data, labels)
+    import root_numpy
+    root_data = pandas.DataFrame(original, columns=['feature%d' % i for i in range(n_dimensions)])
+    predictions = predict_by_estimator(root_data, estimator)
+    with tempfile.NamedTemporaryFile(mode="w", suffix='.root', dir='.', delete=True) as rootfile:
+        fname = rootfile.name
+        root_numpy.array2root(root_data.to_records(index=False), fname, treename='tree', mode='recreate')
+        predict_rootfile_by_estimator(fname, 'tree', len(predictions), estimator,
+                                      ['feature%d' % i for i in range(n_dimensions)], training_selection=None,
+                                      chunk=100, id_column_name='ID_VAR', id_column_dtype='i8', id_column_exist=False,
+                                      estimator_column_name='BDT', estimator_column_dtype='f8')
+        added_column = root_numpy.root2array(fname, 'tree', branches=['BDT'])['BDT']
+        print(added_column)
+        print(predictions)
+        assert numpy.allclose(added_column, predictions), 'Predictions are different in the root file and initial ones'
+
+
+def test_add_predictions_reweighter():
+    reweighter = GBReweighter(max_depth=3, n_estimators=30, learning_rate=0.3, gb_args=dict(subsample=0.3))
+    check_estimator(reweighter, n_dimensions=2, n_samples=200000)
+
+
+def test_add_predictions_classifier():
+    classifier = GradientBoostingClassifier()
+    check_estimator(classifier, n_dimensions=2, n_samples=10000)
+
+
+def test_add_predictions_regressor():
+    regressor = GradientBoostingRegressor()
+    check_estimator(regressor, n_dimensions=2, n_samples=10000)


### PR DESCRIPTION
Add use-case for HEP where ROOT format is used for data. After classifier and reweighter training it is needed to add predictions into root files. Note, that in case of folding scheme training this should be done in a correct way. For this purpose rootutils is added:
* one should provide training selection, file and estimator
* training samples are read and predicted separately from the other samples
* other samples are read and predicted by chunk (in case of huge root file)
* all predictions are added into root file.