### PR TITLE
Avoid sklearn.cross_validation deprecation warning

### DIFF
--- a/hep_ml/commonutils.py
+++ b/hep_ml/commonutils.py
@@ -12,7 +12,12 @@ import itertools
 import numpy
 import pandas
 from scipy.special import expit
-import sklearn.cross_validation
+try:
+    import sklearn.model_selection as sklearn_cross_validation
+except ImportError:
+    # The cross_validation module is deprecated as of sklearn 0.18, in favour
+    # of the model_selection module
+    import sklearn.cross_validation as sklearn_cross_validation
 from sklearn.neighbors.unsupervised import NearestNeighbors
 
 __author__ = "Alex Rogozhnikov"
@@ -102,7 +107,7 @@ def train_test_split(*arrays, **kw_args):
     length = len(arrays[0])
     for array in arrays:
         assert len(array) == length, "different size"
-    train_indices, test_indices = sklearn.cross_validation.train_test_split(range(length), **kw_args)
+    train_indices, test_indices = sklearn_cross_validation.train_test_split(range(length), **kw_args)
     result = []
     for array in arrays:
         if isinstance(array, pandas.DataFrame):


### PR DESCRIPTION
Wraps the `import` of the (new) `sklearn.model_selection` with a `try/except`, falling back to the (old) `sklearn.cross_validation` module on failure. Users upgrading only hep_ml shouldn't see any difference, but users installing hep_ml from scratch will no longer see the deprecation warning.

This fixes #46.