### PR TITLE
Pandas "ix" indexer removed.

### DIFF
--- a/hep_ml/commonutils.py
+++ b/hep_ml/commonutils.py
@@ -254,7 +254,7 @@ def take_features(X, features):
     are_strings = all([isinstance(feature, str) for feature in features])
     are_numbers = all([isinstance(feature, Number) for feature in features])
     if are_strings and isinstance(X, pandas.DataFrame):
-        return X.ix[:, features]
+        return X[features][:]
     elif are_numbers:
         return numpy.array(X)[:, features]
     else:


### PR DESCRIPTION
New indexing added. "ix" indexer was last supported in Pandas 0.25.3.
Tested the new code in Pandas 1.0.0 and Pandas 1.0.1.