### PR TITLE
fix: original weights wrongly normalized

### DIFF
--- a/hep_ml/reweight.py
+++ b/hep_ml/reweight.py
@@ -187,7 +187,7 @@ class BinsReweighter(BaseEstimator, ReweighterMixin):
         :param original_weight: weights of samples before reweighting.
         :return: numpy.array of shape [n_samples] with new weights.
         """
-        original, original_weight = self._normalize_input(original, original_weight)
+        original, original_weight = self._normalize_input(original, original_weight, normalize=False)
         bin_indices = self.compute_bin_indices(original)
         results = self.transition[tuple(bin_indices.T)] * original_weight
         return results
@@ -266,7 +266,7 @@ class GBReweighter(BaseEstimator, ReweighterMixin):
         :param original_weight: weights of samples before reweighting.
         :return: numpy.array of shape [n_samples] with new weights.
         """
-        original, original_weight = self._normalize_input(original, original_weight)
+        original, original_weight = self._normalize_input(original, original_weight, normalize=False)
         multipliers = numpy.exp(self.gb.decision_function(original))
         return multipliers * original_weight
 


### PR DESCRIPTION
When predicting the weights, the original weights should not be normalized (as also written in the docs), I assume this is abug?

Furthermore, I think it should also not normalize in the training method, right? Because if we do (or pass the argument through), there is no way of having different normalizations.

In fact, shouldn't the right way be to _remember_ the normalization?