### PR TITLE
Upgrade sklearn criterion mse to squared_error

### DIFF
--- a/hep_ml/gradientboosting.py
+++ b/hep_ml/gradientboosting.py
@@ -118,7 +118,7 @@ class UGradientBoostingBase(BaseEstimator):
         for stage in range(self.n_estimators):
             # tree creation
             tree = SklearnClusteringTree(
-                criterion='mse',
+                criterion='squared_error',
                 splitter=self.splitter,
                 max_depth=self.max_depth,
                 min_samples_split=self.min_samples_split,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib >= 1.4
 pandas >= 0.14.0
 ipython[all] >= 3.0
 root_numpy >= 3.3.0
-scikit-learn >= 0.19
+scikit-learn >= 1  # criterion is squared_error instead of mse
 theano >= 1.0.2
 six
 sphinx_rtd_theme


### PR DESCRIPTION
mse is deprecated and will be removed: https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeRegressor.html

`squared_error` is equivalent.